### PR TITLE
Implementing DB link update, delete link command and unit tests (Dele…

### DIFF
--- a/Repository.Entities/Link.cs
+++ b/Repository.Entities/Link.cs
@@ -33,5 +33,11 @@ namespace Repository.Entities
 		public virtual Domain Domain { get; set; }
 
 		public virtual ICollection<Artist> Artists { get; set; }
-	}
+
+        /*
+         * TODO: Add optimistic concurrency in the Link Entity, to help mitigate the out of sync of point #4
+         */
+        //[Timestamp]
+        //public byte[] RowVersion { get; set; }
+    }
 }

--- a/Repository.Entities/Repository.Entities.csproj
+++ b/Repository.Entities/Repository.Entities.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Repository.Interfaces/Repository.Interfaces.csproj
+++ b/Repository.Interfaces/Repository.Interfaces.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Repository.Tests/LinkRepositoryTest.cs
+++ b/Repository.Tests/LinkRepositoryTest.cs
@@ -102,6 +102,46 @@ namespace Repository.Tests
 			Assert.AreEqual(link.Artists.Count, saved.Artists.Count);
 		}
 
-		// TODO: implement DB link update + unit tests
-	}
+        [Test]
+        public void UpdateLink_CheckPropertyChanges()
+        {
+            var domain = Builder<Domain>.CreateNew()
+                .With(d => d.Id, Guid.NewGuid())
+                .With(d => d.Name, "domain")
+                .Build();
+
+            // imitates existing entries
+            using (var contex = new Context())
+            {
+                contex.Domains.Add(domain);
+                contex.SaveChanges();
+            }
+
+            var link = Builder<Link>.CreateNew()
+                .With(x => x.Id, Guid.NewGuid())
+                .With(x => x.Domain, domain)
+                .With(x => x.DomainId, domain.Id)
+                .Build();
+
+            var entity = _repository.CreateLink(link);
+
+            var linkToUpdate = _context.Entry(link);
+
+            // make some property changes to the created link
+            linkToUpdate.Property(x => x.Code).CurrentValue = "code";
+            linkToUpdate.Property(x => x.Title).CurrentValue = "title";
+            linkToUpdate.Property(x => x.Url).CurrentValue = "url";
+
+            entity = _repository.UpdateLink(link);
+
+            var updated = _context.Links.Find(entity.Id);
+
+            Assert.IsTrue(entity.IsActive);
+
+            Assert.IsNotNull(updated);
+            Assert.AreEqual(updated.Code, "code");
+            Assert.AreEqual(updated.Title, "title");
+            Assert.AreEqual(updated.Url, "url");
+        }
+    }
 }

--- a/Repository/LinkRepository.cs
+++ b/Repository/LinkRepository.cs
@@ -53,17 +53,24 @@ namespace Repository
 
 		public Link UpdateLink(Link link)
 		{
-			var entry = _context.Entry(link);
+			var entry = _context.Entry<Link>(link);
 
-			// make sure that next fields will be never modified on update
-			entry.Property(x => x.MediaType).IsModified = false;
+            if (entry == null)
+            {
+                throw new Exception($"Link {link.Id} not found.");
+            }
+
+            // make sure that next fields will be never modified on update
+            entry.Property(x => x.MediaType).IsModified = false;
 			entry.Property(x => x.IsActive).IsModified = false;
 
 			_context.Domains.Attach(link.Domain);
+			_context.Links.Attach(link);
 
-			// TODO: implement DB link update
-			throw new NotImplementedException();
-		}
+            _context.Entry(entry.Entity).CurrentValues.SetValues(link);
+            _context.SaveChanges();
+            return link;
+        }
 
 		public Link DeleteLink(Guid linkId)
 		{

--- a/Repository/Repository.csproj
+++ b/Repository/Repository.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Service.Tests/Link/DeleteLinkCommandTest.cs
+++ b/Service.Tests/Link/DeleteLinkCommandTest.cs
@@ -1,12 +1,88 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using FizzWare.NBuilder;
 using NUnit.Framework;
+using Repository.Entities;
+using Repository.Entities.Enums;
+using Repository.Interfaces;
+using Rhino.Mocks;
+using Service.Interfaces.Storage;
+using Service.Link;
 
 namespace Service.Tests.Link
 {
-	[TestFixture]
+    [TestFixture]
 	[ExcludeFromCodeCoverage]
 	public class DeleteLinkCommandTest
 	{
-		// TODO: implement delete link command + unit tests
-	}
+        private IStorage _storageService;
+
+        private ILinkRepository _linkRepository;
+        private IDomainRepository _domainRepository;
+        private IMediaServiceRepository _mediaServiceRepository;
+
+        private DeleteLinkCommand _deleteLinkCommand;
+
+        [SetUp]
+        public void Init()
+        {
+            _linkRepository = MockRepository.GenerateMock<ILinkRepository>();
+            _domainRepository = MockRepository.GenerateMock<IDomainRepository>();
+            _mediaServiceRepository = MockRepository.GenerateMock<IMediaServiceRepository>();
+
+            _storageService = MockRepository.GenerateMock<IStorage>();
+
+            _deleteLinkCommand = new DeleteLinkCommand(_storageService, _domainRepository, _mediaServiceRepository, _linkRepository);
+        }
+
+        [TearDown]
+        public void VerifyAllExpectations()
+        {
+            _storageService.VerifyAllExpectations();
+            _linkRepository.VerifyAllExpectations();
+            _domainRepository.VerifyAllExpectations();
+            _mediaServiceRepository.VerifyAllExpectations();
+        }
+
+        [Test]
+        public void Execute_Delete_Valid_Link()
+        {
+            var domainId = Guid.NewGuid();
+            var domain = Builder<Domain>.CreateNew()
+                .With(x => x.Id, domainId)
+                .Build();
+
+            Guid linkId = Guid.NewGuid();
+            var existDbLink = Builder<Repository.Entities.Link>.CreateNew()
+                .With(x => x.Id, linkId)
+                .With(x => x.IsActive, true)
+                .With(x => x.MediaType, MediaType.Music)
+                .With(x => x.Code, "oldcode")
+                .With(x => x.DomainId, domainId)
+                .With(x => x.Domain, domain)
+                .Build();
+
+            var argument = Builder<DeleteLinkArgument>.CreateNew()
+                .With(x => x.LinkId, linkId)
+                .Build();
+
+            var result = _deleteLinkCommand.Execute(argument);
+
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void Execute_Delete_Invalid_Link()
+        {
+            var invalidId = Guid.NewGuid();
+
+            var argument = Builder<DeleteLinkArgument>.CreateNew()
+                .With(x => x.LinkId, invalidId)
+                .Build();
+
+            var result = _deleteLinkCommand.Execute(argument);
+
+            Assert.IsNull(result);
+        }
+    }
 }

--- a/Service/Link/CreateLinkCommand.cs
+++ b/Service/Link/CreateLinkCommand.cs
@@ -33,148 +33,131 @@ namespace Service.Link
 
 
 		public LinkModel Execute(CreateLinkArgument argument)
-		{
-			var domain = _domainRepository.GetDomain(argument.Link.DomainId);
+        {
+            var domain = _domainRepository.GetDomain(argument.Link.DomainId);
 
-			var code = argument.Link.Code;
-			if (!String.IsNullOrEmpty(code))
-			{
-				if (!LinkHelper.IsValidLinkCode(_storageService, domain.Name, argument.Link.Code))
-				{
-					throw new ArgumentException($"Shortlink {domain.Name}/{argument.Link.Code} is already in use.");
-				}
-			}
-			else
-			{
-				code = LinkHelper.GetUniqueLinkShortCode(_storageService, domain.Name);
-			}
+            var code = argument.Link.Code;
+            if (!String.IsNullOrEmpty(code))
+            {
+                if (!LinkHelper.IsValidLinkCode(_storageService, domain.Name, argument.Link.Code))
+                {
+                    throw new ArgumentException($"Shortlink {domain.Name}/{argument.Link.Code} is already in use.");
+                }
+            }
+            else
+            {
+                code = LinkHelper.GetUniqueLinkShortCode(_storageService, domain.Name);
+            }
 
-			Repository.Entities.Link dbLink;
+            Repository.Entities.Link dbLink;
 
-			switch (argument.Link.MediaType)
-			{
-				case MediaType.Music:
-					var uniqMediaServiceIds =
-						argument.MusicDestinations.SelectMany(x => x.Value.Select(d => d.MediaServiceId)).Distinct().ToList();
-					var mediaServices = _mediaServiceRepository.GetMediaServices().Where(x => uniqMediaServiceIds.Contains(x.Id)).ToList();
+            switch (argument.Link.MediaType)
+            {
+                case MediaType.Music:
+                    var uniqMediaServiceIds =
+                        argument.MusicDestinations.SelectMany(x => x.Value.Select(d => d.MediaServiceId)).Distinct().ToList();
+                    var mediaServices = _mediaServiceRepository.GetMediaServices().Where(x => uniqMediaServiceIds.Contains(x.Id)).ToList();
 
-					var shortLink = LinkHelper.ShortLinkTemplate(domain.Name, code);
-					string generalLinkPath = LinkHelper.LinkGeneralFilenameTemplate(shortLink);
+                    var shortLink = LinkHelper.ShortLinkTemplate(domain.Name, code);
+                    string generalLinkPath = LinkHelper.LinkGeneralFilenameTemplate(shortLink);
 
-					dbLink = _linkRepository.CreateLink(new Repository.Entities.Link()
-					{
-						Code = code,
-						Domain = domain,
-						DomainId = domain.Id,
-						Id = argument.Link.Id,
-						IsActive = argument.Link.IsActive,
-						MediaType = argument.Link.MediaType,
-						Title = argument.Link.Title,
-						Url = argument.Link.Url,
-						Artists = argument.Link.Artists?.Any() == true
-							? argument.Link.Artists.Select(x => new Artist()
-							{
-								Id = x.Id,
-								Name = x.Name,
-								Label = x.Label
-							}).ToList()
-							: null
-					});
+                    dbLink = _linkRepository.CreateLink(new Repository.Entities.Link()
+                    {
+                        Code = code,
+                        Domain = domain,
+                        DomainId = domain.Id,
+                        Id = argument.Link.Id,
+                        IsActive = argument.Link.IsActive,
+                        MediaType = argument.Link.MediaType,
+                        Title = argument.Link.Title,
+                        Url = argument.Link.Url,
+                        Artists = argument.Link.Artists?.Any() == true
+                            ? argument.Link.Artists.Select(x => new Artist()
+                            {
+                                Id = x.Id,
+                                Name = x.Name,
+                                Label = x.Label
+                            }).ToList()
+                            : null
+                    });
 
-					_storageService.Save(generalLinkPath, new StorageModel()
-					{
-						Id = argument.Link.Id,
-						MediaType = argument.Link.MediaType,
-						Url = argument.Link.Url,
-						Title = argument.Link.Title,
-						Destinations = argument.MusicDestinations.ToDictionary(
-							md => md.Key,
-							md => md.Value.Where(d => mediaServices.Select(m => m.Id).Contains(d.MediaServiceId)).Select(d => new DestinationStorageModel()
-							{
-								MediaServiceId = d.MediaServiceId,
-								TrackingInfo = new TrackingStorageModel()
-								{
-									MediaServiceName = mediaServices.First(m => m.Id == d.MediaServiceId).Name,
+                    _storageService.Save(generalLinkPath, new StorageModel()
+                    {
+                        Id = argument.Link.Id,
+                        MediaType = argument.Link.MediaType,
+                        Url = argument.Link.Url,
+                        Title = argument.Link.Title,
+                        Destinations = argument.MusicDestinations.ToDictionary(
+                            md => md.Key,
+                            md => md.Value.Where(d => mediaServices.Select(m => m.Id).Contains(d.MediaServiceId)).Select(d => new DestinationStorageModel()
+                            {
+                                MediaServiceId = d.MediaServiceId,
+                                TrackingInfo = new TrackingStorageModel()
+                                {
+                                    MediaServiceName = mediaServices.First(m => m.Id == d.MediaServiceId).Name,
 
-									Artist = d.TrackingInfo?.Artist,
-									Album = d.TrackingInfo?.Album,
-									SongTitle = d.TrackingInfo?.SongTitle,
+                                    Artist = d.TrackingInfo?.Artist,
+                                    Album = d.TrackingInfo?.Album,
+                                    SongTitle = d.TrackingInfo?.SongTitle,
 
-									Mobile = d.TrackingInfo?.Mobile,
-									Web = d.TrackingInfo?.Web,
-								}
-							}).ToList())
-					});
+                                    Mobile = d.TrackingInfo?.Mobile,
+                                    Web = d.TrackingInfo?.Web,
+                                }
+                            }).ToList())
+                    });
 
-					break;
-				case MediaType.Ticket:
+                    break;
+                case MediaType.Ticket:
 
-					var shortLinkTicket = LinkHelper.ShortLinkTemplate(domain.Name, code);
-					string generalLinkPathTicket = LinkHelper.LinkGeneralFilenameTemplate(shortLinkTicket);
+                    var shortLinkTicket = LinkHelper.ShortLinkTemplate(domain.Name, code);
+                    string generalLinkPathTicket = LinkHelper.LinkGeneralFilenameTemplate(shortLinkTicket);
 
-					dbLink = _linkRepository.CreateLink(new Repository.Entities.Link()
-					{
-						Id = argument.Link.Id,
-						Code = code,
-						Domain = domain,
-						DomainId = domain.Id,
-						IsActive = true,
-						MediaType = argument.Link.MediaType,
-						Title = argument.Link.Title,
-						Url = argument.Link.Url,
-						Artists = argument.Link.Artists?.Any() == true
-							? argument.Link.Artists.Select(x => new Artist()
-							{
-								Id = x.Id,
-								Name = x.Name,
-								Label = x.Label
-							}).ToList()
-							: null
-					});
+                    dbLink = _linkRepository.CreateLink(new Repository.Entities.Link()
+                    {
+                        Id = argument.Link.Id,
+                        Code = code,
+                        Domain = domain,
+                        DomainId = domain.Id,
+                        IsActive = true,
+                        MediaType = argument.Link.MediaType,
+                        Title = argument.Link.Title,
+                        Url = argument.Link.Url,
+                        Artists = argument.Link.Artists?.Any() == true
+                            ? argument.Link.Artists.Select(x => new Artist()
+                            {
+                                Id = x.Id,
+                                Name = x.Name,
+                                Label = x.Label
+                            }).ToList()
+                            : null
+                    });
 
-					_storageService.Save(generalLinkPathTicket, new Models.StorageModel.Ticket.StorageModel()
-					{
-						Id = argument.Link.Id,
-						MediaType = argument.Link.MediaType,
-						Url = argument.Link.Url,
-						Title = argument.Link.Title,
-						Destinations = argument.TicketDestinations.ToDictionary(
-							md => md.Key,
-							md => md.Value.Select(d => new Models.StorageModel.Ticket.DestinationStorageModel()
-							{
-								ShowId = d.ShowId,
-								MediaServiceId = d.MediaServiceId,
-								Url = d.Url,
-								Date = d.Date,
-								Location = d.Location,
-								Venue = d.Venue
-							}).ToList())
-					});
-					break;
-				default:
-					throw new NotSupportedException($"Link type {argument.Link.MediaType} is not supported.");
-			}
+                    _storageService.Save(generalLinkPathTicket, new Models.StorageModel.Ticket.StorageModel()
+                    {
+                        Id = argument.Link.Id,
+                        MediaType = argument.Link.MediaType,
+                        Url = argument.Link.Url,
+                        Title = argument.Link.Title,
+                        Destinations = argument.TicketDestinations.ToDictionary(
+                            md => md.Key,
+                            md => md.Value.Select(d => new Models.StorageModel.Ticket.DestinationStorageModel()
+                            {
+                                ShowId = d.ShowId,
+                                MediaServiceId = d.MediaServiceId,
+                                Url = d.Url,
+                                Date = d.Date,
+                                Location = d.Location,
+                                Venue = d.Venue
+                            }).ToList())
+                    });
+                    break;
+                default:
+                    throw new NotSupportedException($"Link type {argument.Link.MediaType} is not supported.");
+            }
+            return LinkHelper.GenerateLinkModel(dbLink);
+        }
 
-			return new LinkModel()
-			{
-				Id = dbLink.Id,
-				Code = code,
-				DomainId = domain.Id,
-				IsActive = dbLink.IsActive,
-				MediaType = dbLink.MediaType,
-				Title = dbLink.Title,
-				Url = dbLink.Url,
-				Artists = dbLink.Artists?.Any() == true
-					? dbLink.Artists.Select(x => new ArtistModel()
-					{
-						Id = x.Id,
-						Name = x.Name,
-						Label = x.Label
-					}).ToList()
-					: null
-			};
-		}
-	}
+    }
 
 	/// <summary>
 	/// Data required for link creation

--- a/Service/Link/DeleteLinkCommand.cs
+++ b/Service/Link/DeleteLinkCommand.cs
@@ -1,16 +1,34 @@
 ﻿using System;
+using Repository.Interfaces;
 using Service.Interfaces.Commands;
+using Service.Interfaces.Storage;
+using Service.Models.Link;
 
 namespace Service.Link
 {
-	public class DeleteLinkCommand: ICommand<DeleteLinkArgument>
+	public class DeleteLinkCommand: ICommand<LinkModel, DeleteLinkArgument>
 	{
-		public void Execute(DeleteLinkArgument argument)
+        private readonly IStorage _storageService;
+        private readonly IDomainRepository _domainRepository;
+        private readonly IMediaServiceRepository _mediaServiceRepository;
+        private readonly ILinkRepository _linkRepository;
+        public DeleteLinkCommand(
+            IStorage storageService,
+            IDomainRepository domainRepository,
+            IMediaServiceRepository mediaServiceRepository,
+            ILinkRepository linkRepository)
+        {
+            _storageService = storageService;
+            _domainRepository = domainRepository;
+            _mediaServiceRepository = mediaServiceRepository;
+            _linkRepository = linkRepository;
+        }
+        public LinkModel Execute(DeleteLinkArgument argument)
 		{
-			// TODO: implement delete link command
-			throw new NotImplementedException();
-		}
-	}
+            var dbLink = _linkRepository.DeleteLink(argument.LinkId);
+            return LinkHelper.GenerateLinkModel(dbLink);
+        }
+    }
 
 	public class DeleteLinkArgument
 	{

--- a/Service/Link/LinkHelper.cs
+++ b/Service/Link/LinkHelper.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Repository.Entities;
 using Service.Interfaces.Storage;
+using Service.Models;
+using Service.Models.Link;
 
 namespace Service.Link
 {
@@ -55,5 +58,28 @@ namespace Service.Link
 
 			return true;
 		}
-	}
+
+        public static LinkModel GenerateLinkModel(Repository.Entities.Link dbLink)
+        {
+            return new LinkModel()
+            {
+                Id = dbLink.Id,
+                Code = dbLink.Code,
+                DomainId = dbLink.DomainId,
+                IsActive = dbLink.IsActive,
+                MediaType = dbLink.MediaType,
+                Title = dbLink.Title,
+                Url = dbLink.Url,
+                Artists = dbLink.Artists?.Any() == true
+                    ? dbLink.Artists.Select(x => new ArtistModel()
+                    {
+                        Id = x.Id,
+                        Name = x.Name,
+                        Label = x.Label
+                    }).ToList()
+                    : null
+            };
+        }
+
+    }
 }


### PR DESCRIPTION
Implementing DB link update, delete link command and unit tests (DeleteCommandTest & LinkRepositoryTest)

## Fixed issues:

Added a new helper method (LinkHelper.cs) to allow mapping Link to LinkModel, this will help that every command can use this static method and not duplicate the mapping on each returning argument

## Found issues:

- Add automapper on the Service side for example: CreateLinkCommand for each mapping between the models present in the lambda 
- The entity Link (Repository.Entities/Link.cs) should have a property row version, adding optimistic concurrency and avoid DB entity and Storage model be out of sync.

## Comments *(optional)*:
